### PR TITLE
Amended logic to retrieve alerts for all people

### DIFF
--- a/CautionaryAlertsApi.Tests/V1/Controllers/CautionaryAlertsControllerTests.cs
+++ b/CautionaryAlertsApi.Tests/V1/Controllers/CautionaryAlertsControllerTests.cs
@@ -17,13 +17,13 @@ namespace CautionaryAlertsApi.Tests.V1.Controllers
     public class CautionaryAlertsControllerTests
     {
         private CautionaryAlertsApiController _classUnderTest;
-        private Mock<IGetAlertsForPerson> _mockGetAlertsForPersonUseCase;
+        private Mock<IGetAlertsForPeople> _mockGetAlertsForPersonUseCase;
         private Mock<IGetCautionaryAlertsForProperty> _mockGetAlertsForPropertyUseCase;
 
         [SetUp]
         public void SetUp()
         {
-            _mockGetAlertsForPersonUseCase = new Mock<IGetAlertsForPerson>();
+            _mockGetAlertsForPersonUseCase = new Mock<IGetAlertsForPeople>();
             _mockGetAlertsForPropertyUseCase = new Mock<IGetCautionaryAlertsForProperty>();
             _classUnderTest = new CautionaryAlertsApiController(_mockGetAlertsForPersonUseCase.Object, _mockGetAlertsForPropertyUseCase.Object);
         }

--- a/CautionaryAlertsApi.Tests/V1/UseCase/GetAlertsForPersonTests.cs
+++ b/CautionaryAlertsApi.Tests/V1/UseCase/GetAlertsForPersonTests.cs
@@ -16,14 +16,14 @@ namespace CautionaryAlertsApi.Tests.V1.UseCase
     public class GetAlertsForPersonTests
     {
         private Mock<IUhGateway> _mockGateway;
-        private GetAlertsForPerson _classUnderTest;
+        private GetAlertsForPeople _classUnderTest;
         private readonly Fixture _fixture = new Fixture();
 
         [SetUp]
         public void SetUp()
         {
             _mockGateway = new Mock<IUhGateway>();
-            _classUnderTest = new GetAlertsForPerson(_mockGateway.Object);
+            _classUnderTest = new GetAlertsForPeople(_mockGateway.Object);
         }
 
         [Test]
@@ -32,7 +32,7 @@ namespace CautionaryAlertsApi.Tests.V1.UseCase
             var tagRef = _fixture.Create<string>();
             var personNo = _fixture.Create<string>();
             var gatewayResponse = _fixture.CreateMany<CautionaryAlertPerson>().ToList();
-            _mockGateway.Setup(x => x.GetCautionaryAlertsForAPerson(tagRef, personNo))
+            _mockGateway.Setup(x => x.GetCautionaryAlertsForPeople(tagRef, personNo))
                 .Returns(gatewayResponse);
 
             _classUnderTest.Execute(tagRef, personNo).Contacts.Should().BeEquivalentTo(gatewayResponse.ToResponse());
@@ -42,7 +42,7 @@ namespace CautionaryAlertsApi.Tests.V1.UseCase
         public void IfTheGatewayReturnsEmptyListThrowPersonNotFound()
         {
             _mockGateway.Setup(x =>
-                    x.GetCautionaryAlertsForAPerson("tagRef", "personNo"))
+                    x.GetCautionaryAlertsForPeople("tagRef", "personNo"))
                 .Returns(new List<CautionaryAlertPerson>());
 
             Func<ListPersonsCautionaryAlerts> testDelegate = () => _classUnderTest.Execute("tagRef", "personNo");

--- a/CautionaryAlertsApi/Startup.cs
+++ b/CautionaryAlertsApi/Startup.cs
@@ -124,7 +124,7 @@ namespace CautionaryAlertsApi
 
         private static void RegisterUseCases(IServiceCollection services)
         {
-            services.AddScoped<IGetAlertsForPerson, GetAlertsForPerson>();
+            services.AddScoped<IGetAlertsForPeople, GetAlertsForPeople>();
             services.AddScoped<IGetCautionaryAlertsForProperty, GetCautionaryAlertsForProperty>();
 
         }

--- a/CautionaryAlertsApi/V1/Controllers/CautionaryAlertsApiController.cs
+++ b/CautionaryAlertsApi/V1/Controllers/CautionaryAlertsApiController.cs
@@ -14,11 +14,11 @@ namespace CautionaryAlertsApi.V1.Controllers
     [ApiVersion("1.0")]
     public class CautionaryAlertsApiController : BaseController
     {
-        private readonly IGetAlertsForPerson _getAlertsForPerson;
+        private readonly IGetAlertsForPeople _getAlertsForPeople;
         private readonly IGetCautionaryAlertsForProperty _getCautionaryAlertsForProperty;
-        public CautionaryAlertsApiController(IGetAlertsForPerson getAlertsForPerson, IGetCautionaryAlertsForProperty getCautionaryAlertsForProperty)
+        public CautionaryAlertsApiController(IGetAlertsForPeople getAlertsForPeople, IGetCautionaryAlertsForProperty getCautionaryAlertsForProperty)
         {
-            _getAlertsForPerson = getAlertsForPerson;
+            _getAlertsForPeople = getAlertsForPeople;
             _getCautionaryAlertsForProperty = getCautionaryAlertsForProperty;
         }
 
@@ -33,12 +33,12 @@ namespace CautionaryAlertsApi.V1.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [HttpGet]
         [Route("people")]
-        public IActionResult ViewPersonsCautionaryAlerts([FromQuery(Name = "tag_ref"), BindRequired] string tagRef,
-            [FromQuery(Name = "person_number"), BindRequired] string personNo)
+        public IActionResult ViewPeopleCautionaryAlerts([FromQuery(Name = "tag_ref"), BindRequired] string tagRef,
+            [FromQuery(Name = "person_number")] string personNo)
         {
             try
             {
-                return Ok(_getAlertsForPerson.Execute(tagRef, personNo));
+                return Ok(_getAlertsForPeople.Execute(tagRef, personNo));
             }
             catch (PersonNotFoundException)
             {

--- a/CautionaryAlertsApi/V1/Gateways/IUhGateway.cs
+++ b/CautionaryAlertsApi/V1/Gateways/IUhGateway.cs
@@ -5,7 +5,7 @@ namespace CautionaryAlertsApi.V1.Gateways
 {
     public interface IUhGateway
     {
-        List<CautionaryAlertPerson> GetCautionaryAlertsForAPerson(string tagRef, string personNumber);
+        List<CautionaryAlertPerson> GetCautionaryAlertsForPeople(string tagRef, string personNumber);
         CautionaryAlertsProperty GetCautionaryAlertsForAProperty(string propertyReference);
     }
 }

--- a/CautionaryAlertsApi/V1/Gateways/UhGateway.cs
+++ b/CautionaryAlertsApi/V1/Gateways/UhGateway.cs
@@ -10,17 +10,16 @@ namespace CautionaryAlertsApi.V1.Gateways
     public class UhGateway : IUhGateway
     {
         private readonly UhContext _uhContext;
-
         public UhGateway(UhContext uhContext)
         {
             _uhContext = uhContext;
         }
 
-        public List<CautionaryAlertPerson> GetCautionaryAlertsForAPerson(string tagRef, string personNumber)
+        public List<CautionaryAlertPerson> GetCautionaryAlertsForPeople(string tagRef, string personNumber)
         {
             var links = _uhContext.ContactLinks
                 .Where(c => c.Key == tagRef)
-                .Where(c => c.PersonNumber == personNumber)
+                .Where(c => string.IsNullOrEmpty(personNumber) || c.PersonNumber == personNumber)
                 .ToList();
 
             return links.Select(link =>

--- a/CautionaryAlertsApi/V1/UseCase/GetAlertsForPeople.cs
+++ b/CautionaryAlertsApi/V1/UseCase/GetAlertsForPeople.cs
@@ -7,17 +7,17 @@ using CautionaryAlertsApi.V1.UseCase.Interfaces;
 
 namespace CautionaryAlertsApi.V1.UseCase
 {
-    public class GetAlertsForPerson : IGetAlertsForPerson
+    public class GetAlertsForPeople : IGetAlertsForPeople
     {
         private IUhGateway _gateway;
-        public GetAlertsForPerson(IUhGateway gateway)
+        public GetAlertsForPeople(IUhGateway gateway)
         {
             _gateway = gateway;
         }
 
         public ListPersonsCautionaryAlerts Execute(string tagRef, string personNo)
         {
-            var gatewayResponse = _gateway.GetCautionaryAlertsForAPerson(tagRef, personNo);
+            var gatewayResponse = _gateway.GetCautionaryAlertsForPeople(tagRef, personNo);
             if (!gatewayResponse.Any()) throw new PersonNotFoundException();
 
             return new ListPersonsCautionaryAlerts

--- a/CautionaryAlertsApi/V1/UseCase/Interfaces/IGetAlertsForPeople.cs
+++ b/CautionaryAlertsApi/V1/UseCase/Interfaces/IGetAlertsForPeople.cs
@@ -2,7 +2,7 @@ using CautionaryAlertsApi.V1.Boundary.Response;
 
 namespace CautionaryAlertsApi.V1.UseCase.Interfaces
 {
-    public interface IGetAlertsForPerson
+    public interface IGetAlertsForPeople
     {
         ListPersonsCautionaryAlerts Execute(string tagRef, string personNo);
     }

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -48,7 +48,7 @@ CREATE TABLE dbo."CCContactLink"(
 );
 
 
-CREATE TABLE dbo.CCEmailAddress(
+CREATE TABLE dbo."CCEmailAddress"(
 	"ContactNo" int NOT NULL,
 	"Email" varchar(50) NOT NULL,
 	"EmailType" varchar(5) NOT NULL,
@@ -62,7 +62,7 @@ CREATE TABLE dbo.CCEmailAddress(
 );
 
 
-CREATE TABLE dbo.CCPhone(
+CREATE TABLE dbo."CCPhone"(
 	"ContactNo" int NOT NULL,
 	"PhoneNo" varchar(20) NOT NULL,
 	"PhoneType" varchar(1) NULL,


### PR DESCRIPTION
Amended logic to retrieve alerts for all people under the same tenancy.

## Link to JIRA ticket

https://hackney.atlassian.net/jira/software/projects/PA/boards/35?selectedIssue=PA-366

## Describe this PR

Previously, endpoint had a required parameter "person_number", which meant it is retrieving alerts only for a single person in a tenancy. Amended the existing logic to account for two scenarios: 1) Retrieving alerts for a specific person in a tenancy and retrieving alerts for all people under a tenancy

### *What changes have we introduced*

- Amended logic
- Added more tests
- Removed a test which was checking if 400 error is returned if person number is not supplied. This is no longer relevant as the parameter is no longer mandatory 


#### _Checklist_

- [X] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [X] Added tests to cover all new production code
- [X] Checked all code for possible refactoring
- [X] Code pipeline builds correctly

### *Follow up actions after merging PR*

Possibly discuss if we should be returning a response if no cautionary alerts for a person are found but a contact link is?
