### PR TITLE
Tiny: Fix typo in ssm parameter names

### DIFF
--- a/CautionaryAlertsApi/serverless.yml
+++ b/CautionaryAlertsApi/serverless.yml
@@ -16,8 +16,8 @@ functions:
     role: lambdaExecutionRole
     environment:
       CONNECTION_STRING: Host=${ssm:/uh-api/${self:provider.stage}/postgres-hostname};Port=${ssm:/uh-api/${self:provider.stage}/postgres-port};Database=uh_mirror;Username=${ssm:/uh-api/${self:provider.stage}/postgres-username};Password=${ssm:/uh-api/${self:provider.stage}/postgres-password}
-      SPREADSHEET_ID: ${ssm:/${self:service}/${self:provider.stage}/googlesheets-spreadsheetid}
-      CREDENTIAL_JSON: ${ssm:/${self:service}/${self:provider.stage}/googlesheets-credentialjson}
+      SPREADSHEET_ID: ${ssm:/${self:service}/${self:provider.stage}/googlesheet-spreadsheetid}
+      CREDENTIAL_JSON: ${ssm:/${self:service}/${self:provider.stage}/googlesheet-credentialjson}
     events:
       - http:
           path: /{proxy+}


### PR DESCRIPTION
Parameters in sls are pluralised yet in SSM they are not -> can't find config items.