### PR TITLE
Add fix to EntityFactory method

### DIFF
--- a/CautionaryAlertsApi.Tests/V1/Factories/EntityFactoryTest.cs
+++ b/CautionaryAlertsApi.Tests/V1/Factories/EntityFactoryTest.cs
@@ -3,26 +3,79 @@ using CautionaryAlertsApi.V1.Infrastructure;
 using CautionaryAlertsApi.V1.Factories;
 using FluentAssertions;
 using NUnit.Framework;
+using System.Linq;
+using System;
+using CautionaryAlertsApi.V1.Gateways;
 
 namespace CautionaryAlertsApi.Tests.V1.Factories
 {
     [TestFixture]
     public class EntityFactoryTest
     {
+        private readonly Fixture _fixture = new Fixture();
+
         [Test]
         public void CanMapAPersonAlertToCautionaryAlertWithDescription()
         {
-            var fixture = new Fixture();
-            var entity = fixture.Create<PersonAlert>();
-            var description = fixture.Create<string>();
+            // Arrange
+            var entity = _fixture.Create<PersonAlert>();
+            var description = _fixture.Create<string>();
+
+            // Act
             var response = entity.ToDomain(description);
 
+            // Assert
             response.Description.Should().Be(description);
             response.AlertCode.Should().Be(entity.AlertCode);
             response.DateModified.Should().Be(entity.DateModified);
             response.EndDate.Should().Be(entity.EndDate);
             response.StartDate.Should().Be(entity.StartDate);
             response.ModifiedBy.Should().Be(entity.ModifiedBy);
+        }
+
+        [Test]
+        public void CanMapRowsToCautionaryAlertListItem()
+        {
+            // Arrange
+            var numColumns = 16;
+            var row = _fixture.CreateMany<string>(numColumns).ToList();
+
+            // Act
+            var result = EntityFactory.ToModel(row);
+
+            // Assert
+            result.Name.Should().Be(row[0]);
+            result.DoorNumber.Should().Be(row[1]);
+            result.Address.Should().Be(row[2]);
+            result.Neighbourhood.Should().Be(row[3]);
+            result.DateOfIncident.Should().Be(row[4]);
+            result.NumberOfDaysOutstanding.Should().Be(row[5]);
+            result.Code.Should().Be(row[6]);
+            result.LetterSent.Should().Be(row[7]);
+            result.OnCivica.Should().Be(row[8]);
+            result.Outcome.Should().Be(row[9]);
+            result.CautionOnSystem.Should().Be(row[10]);
+            result.ActionOnAssure.Should().Be(row[11]);
+            result.Lookup.Should().Be(row[12]);
+            result.PropertyReference.Should().Be(row[13]);
+            result.TenancyDates.Should().Be(row[14]);
+            result.IncidentBeforeCurrentTenancyDate.Should().Be(row[15]);
+        }
+
+        [Test]
+        public void DoesntThrowIndexOutOfRangeExceptionWhenMissingColumns()
+        {
+            // Arrange
+            var numColumns = 16;
+            var realNumColumns = numColumns - 1;
+
+            var row = _fixture.CreateMany<string>(realNumColumns).ToList();
+
+            // Act
+            Func<CautionaryAlertListItem> task = () => EntityFactory.ToModel(row);
+
+            // Assert
+            task.Should().NotThrow<IndexOutOfRangeException>();
         }
     }
 }

--- a/CautionaryAlertsApi/V1/Factories/EntityFactory.cs
+++ b/CautionaryAlertsApi/V1/Factories/EntityFactory.cs
@@ -1,8 +1,8 @@
-using System.Collections.Generic;
-using System.Linq;
 using CautionaryAlertsApi.V1.Domain;
 using CautionaryAlertsApi.V1.Gateways;
 using CautionaryAlertsApi.V1.Infrastructure;
+using System.Collections.Generic;
+using System.Linq;
 using PropertyAlert = CautionaryAlertsApi.V1.Infrastructure.PropertyAlert;
 
 namespace CautionaryAlertsApi.V1.Factories
@@ -37,25 +37,34 @@ namespace CautionaryAlertsApi.V1.Factories
         public static CautionaryAlertListItem ToModel(this IEnumerable<string> row)
         {
             var rowArray = row.ToArray();
+
             return new CautionaryAlertListItem
             {
-                Name = rowArray[0],
-                DoorNumber = rowArray[1],
-                Address = rowArray[2],
-                Neighbourhood = rowArray[3],
-                DateOfIncident = rowArray[4],
-                NumberOfDaysOutstanding = rowArray[5],
-                Code = rowArray[6],
-                LetterSent = rowArray[7],
-                OnCivica = rowArray[8],
-                Outcome = rowArray[9],
-                CautionOnSystem = rowArray[10],
-                ActionOnAssure = rowArray[11],
-                Lookup = rowArray[12],
-                PropertyReference = rowArray[13],
-                TenancyDates = rowArray[14],
-                IncidentBeforeCurrentTenancyDate = rowArray[15]
+                Name = ReadColumn(rowArray, 0),
+                DoorNumber = ReadColumn(rowArray, 1),
+                Address = ReadColumn(rowArray, 2),
+                Neighbourhood = ReadColumn(rowArray, 3),
+                DateOfIncident = ReadColumn(rowArray, 4),
+                NumberOfDaysOutstanding = ReadColumn(rowArray, 5),
+                Code = ReadColumn(rowArray, 6),
+                LetterSent = ReadColumn(rowArray, 7),
+                OnCivica = ReadColumn(rowArray, 8),
+                Outcome = ReadColumn(rowArray, 9),
+                CautionOnSystem = ReadColumn(rowArray, 10),
+                ActionOnAssure = ReadColumn(rowArray, 11),
+                Lookup = ReadColumn(rowArray, 12),
+                PropertyReference = ReadColumn(rowArray, 13),
+                TenancyDates = ReadColumn(rowArray, 14),
+                IncidentBeforeCurrentTenancyDate = ReadColumn(rowArray, 15)
             };
+        }
+
+        private static string ReadColumn(string[] rowArray, int index)
+        {
+            // prevent IndexOutOfRangeException
+            if (rowArray.Length < index + 1) return null;
+
+            return rowArray[index];
         }
     }
 }


### PR DESCRIPTION
## Describe this PR
I found two properties that caused the API to return a 500 status. 

I believe this occurs because the last column in GoogleSheets was missing a value, and therefore the GoogleSheet API returns an array without that index, causing an IndexOutOfRangeException.

[/api/v1/cautionary-alerts/sheets/properties/00002876](https://wv694tecog.execute-api.eu-west-2.amazonaws.com/staging/api/v1/cautionary-alerts/sheets/properties/00002876)
[/api/v1/cautionary-alerts/sheets/properties/00010751](https://wv694tecog.execute-api.eu-west-2.amazonaws.com/staging/api/v1/cautionary-alerts/sheets/properties/00010751)

To solve this, I have added a check to make sure the array contains the index.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly