### PR TITLE
Add NullOrWhitespace check in ViewPropertyCautionaryAlerts endpoint.

### DIFF
--- a/CautionaryAlertsApi.Tests/V1/Controllers/CautionaryAlertsControllerTests.cs
+++ b/CautionaryAlertsApi.Tests/V1/Controllers/CautionaryAlertsControllerTests.cs
@@ -59,5 +59,19 @@ namespace CautionaryAlertsApi.Tests.V1.Controllers
             response.Value.Should().Be($"Property cautionary alert(s) for property reference {propertyReference} not found");
             response.StatusCode.Should().Be(404);
         }
+
+        [TestCase("")]
+        [TestCase(" ")]
+        [TestCase(null)]
+        public void ViewPropertyCautionaryAlertsWhenTagRefIsNullOrWhiteSpaceReturnsBadRequest(string tagRef)
+        {
+            // Arrange
+
+            // Act
+            var response = _classUnderTest.ViewPeopleCautionaryAlerts(tagRef, string.Empty) as BadRequestObjectResult;
+
+            // Assert
+            response.StatusCode.Should().Be(400);
+        }
     }
 }

--- a/CautionaryAlertsApi/V1/Controllers/CautionaryAlertsApiController.cs
+++ b/CautionaryAlertsApi/V1/Controllers/CautionaryAlertsApiController.cs
@@ -29,13 +29,20 @@ namespace CautionaryAlertsApi.V1.Controllers
         /// <param name="personNo">The number of the person you are interested in within a property. person_no in UH. e.g. 01</param>
         /// <response code="200">Successful. One or more records found for given tag_ref and person_no</response>
         /// <response code="404">No records found for given tag_ref and person_no</response>
+        /// <response code="400">Bad request - tag_ref cannot be null or whitespace</response>
         [ProducesResponseType(typeof(ListPersonsCautionaryAlerts), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [HttpGet]
         [Route("people")]
         public IActionResult ViewPeopleCautionaryAlerts([FromQuery(Name = "tag_ref"), BindRequired] string tagRef,
             [FromQuery(Name = "person_number")] string personNo)
         {
+            if (string.IsNullOrWhiteSpace(tagRef))
+            {
+                return BadRequest($"Parameter {nameof(tagRef)} cannot be null or whitespace");
+            }
+
             try
             {
                 return Ok(_getAlertsForPeople.Execute(tagRef, personNo));


### PR DESCRIPTION
Currently returns 502 BadGateway when tagRef is null, instead of BadRequest

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly