### PR TITLE
MTTL-2773: Implement get alerts by MMH person ID endpoint

### DIFF
--- a/CautionaryAlertsApi.Tests/V1/Controllers/CautionaryAlertsControllerTests.cs
+++ b/CautionaryAlertsApi.Tests/V1/Controllers/CautionaryAlertsControllerTests.cs
@@ -22,6 +22,7 @@ namespace CautionaryAlertsApi.Tests.V1.Controllers
         private Mock<IGetAlertsForPeople> _mockGetAlertsForPersonUseCase;
         private Mock<IGetCautionaryAlertsForProperty> _mockGetAlertsForPropertyUseCase;
         private Mock<IPropertyAlertsNewUseCase> _mockGetPropertyAlertsNewUseCase;
+        private Mock<IGetCautionaryAlertsByPersonId> _mockGetCautionaryAlertsByPersonIdUseCase;
 
         private readonly Fixture _fixture = new Fixture();
 
@@ -31,11 +32,13 @@ namespace CautionaryAlertsApi.Tests.V1.Controllers
             _mockGetAlertsForPersonUseCase = new Mock<IGetAlertsForPeople>();
             _mockGetAlertsForPropertyUseCase = new Mock<IGetCautionaryAlertsForProperty>();
             _mockGetPropertyAlertsNewUseCase = new Mock<IPropertyAlertsNewUseCase>();
+            _mockGetCautionaryAlertsByPersonIdUseCase = new Mock<IGetCautionaryAlertsByPersonId>();
 
             _classUnderTest = new CautionaryAlertsApiController(
                 _mockGetAlertsForPersonUseCase.Object,
                 _mockGetAlertsForPropertyUseCase.Object,
-                _mockGetPropertyAlertsNewUseCase.Object);
+                _mockGetPropertyAlertsNewUseCase.Object,
+                _mockGetCautionaryAlertsByPersonIdUseCase.Object);
         }
 
         [Test]
@@ -89,7 +92,28 @@ namespace CautionaryAlertsApi.Tests.V1.Controllers
             response.Should().NotBeNull();
             response.StatusCode.Should().Be(200);
             response.Value.Should().BeEquivalentTo(usecaseResponse);
+        }
 
+        [Test]
+        public async Task GetAlertsByPersonIdReturnsAlertsFromUseCase()
+        {
+            // Arrange
+            var personId = Guid.NewGuid();
+
+            var usecaseResponse = _fixture.Create<CautionaryAlertsMMHPersonResponse>();
+
+            _mockGetCautionaryAlertsByPersonIdUseCase
+                .Setup(x => x.ExecuteAsync(personId))
+                .ReturnsAsync(usecaseResponse);
+
+            // Act
+            var response = await _classUnderTest.GetAlertsByPersonId(personId).ConfigureAwait(false) as OkObjectResult;
+
+            // Assert
+            response.Should().NotBeNull();
+            response.StatusCode.Should().Be(200);
+            response.Value.Should().BeEquivalentTo(usecaseResponse);
+            _mockGetCautionaryAlertsByPersonIdUseCase.Verify(x => x.ExecuteAsync(personId), Times.Once);
         }
     }
 }

--- a/CautionaryAlertsApi.Tests/V1/E2ETests/GetAlertsByPersonIdE2ETests.cs
+++ b/CautionaryAlertsApi.Tests/V1/E2ETests/GetAlertsByPersonIdE2ETests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AutoFixture;
+using CautionaryAlertsApi.Tests.V1.Helper;
+using CautionaryAlertsApi.V1.Boundary.Response;
+using CautionaryAlertsApi.V1.Infrastructure;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace CautionaryAlertsApi.Tests.V1.E2ETests
+{
+    public class GetAlertsByPersonIdE2ETests : IntegrationTests<Startup>
+    {
+        private readonly Fixture _fixture = new Fixture();
+
+        [Test]
+        public async Task GetAlertsByPersonIdReturnsEmptyArrayWhenNoneExist()
+        {
+            // Arrange
+            var id = Guid.NewGuid();
+            var url = new Uri($"/api/v1/cautionary-alerts/persons/{id}", UriKind.Relative);
+
+            // Act
+            var response = await Client.GetAsync(url).ConfigureAwait(true);
+
+            // Assert
+            response.StatusCode.Should().Be(200);
+
+            var data = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var returnedAlerts = JsonConvert.DeserializeObject<CautionaryAlertsMMHPersonResponse>(data);
+
+            returnedAlerts.PersonId.Should().Be(id);
+            returnedAlerts.Alerts.Should().BeEmpty();
+        }
+
+
+        [Test]
+        public async Task GetAlertsByPersonIdReturnsAlertsIfTheyExist()
+        {
+            // Arrange
+            var id = Guid.NewGuid();
+
+            var alerts = _fixture.Build<PropertyAlertNew>()
+                .With(x => x.MMHID, id.ToString())
+                .CreateMany();
+            await TestDataHelper.SavePropertyAlertsToDb(UhContext, alerts).ConfigureAwait(false);
+
+            var url = new Uri($"/api/v1/cautionary-alerts/persons/{id}", UriKind.Relative);
+            // Act
+            var response = await Client.GetAsync(url).ConfigureAwait(true);
+
+            // Assert
+            response.StatusCode.Should().Be(200);
+
+            var data = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var returnedAlerts = JsonConvert.DeserializeObject<CautionaryAlertsMMHPersonResponse>(data);
+
+            returnedAlerts.PersonId.Should().Be(id);
+            returnedAlerts.Alerts.Should().HaveSameCount(alerts);
+        }
+    }
+}

--- a/CautionaryAlertsApi.Tests/V1/Gateways/UhGatewayTests.cs
+++ b/CautionaryAlertsApi.Tests/V1/Gateways/UhGatewayTests.cs
@@ -398,5 +398,39 @@ namespace CautionaryAlertsApi.Tests.V1.Gateways
             result.Should().NotBeNull();
             result.Should().HaveCount(numberOfResults);
         }
+
+        [Test]
+        public async Task GetCautionaryAlertsByPersonIdReturnsEmptyList()
+        {
+            // Arrange
+            var personId = Guid.NewGuid();
+
+            // Act
+            var result = await _classUnderTest.GetCautionaryAlertsByMMHPersonId(personId).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task GetGetCautionaryAlertsByPersonIdReturnsMany()
+        {
+            // Arrange
+            var personId = Guid.NewGuid();
+            var results = _fixture.Build<PropertyAlertNew>()
+                .With(x => x.MMHID, personId.ToString())
+                .CreateMany();
+
+            await TestDataHelper.SavePropertyAlertsToDb(UhContext, results).ConfigureAwait(false);
+
+            // Act
+            var result = await _classUnderTest.GetCautionaryAlertsByMMHPersonId(personId).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().HaveSameCount(results);
+        }
+
     }
 }

--- a/CautionaryAlertsApi.Tests/V1/UseCase/GetCautionaryAlertsByPersonIdUseCaseTests.cs
+++ b/CautionaryAlertsApi.Tests/V1/UseCase/GetCautionaryAlertsByPersonIdUseCaseTests.cs
@@ -1,0 +1,67 @@
+using AutoFixture;
+using CautionaryAlertsApi.V1.Gateways;
+using CautionaryAlertsApi.V1.UseCase;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace CautionaryAlertsApi.Tests.V1.UseCase
+{
+    public class GetCautionaryAlertsByPersonIdUseCaseTests
+    {
+        private readonly GetCautionaryAlertsByPersonIdUseCase _classUnderTest;
+        private readonly Mock<IUhGateway> _mockGateway;
+
+        private readonly Fixture _fixture = new Fixture();
+
+        public GetCautionaryAlertsByPersonIdUseCaseTests()
+        {
+            _mockGateway = new Mock<IUhGateway>();
+            _classUnderTest = new GetCautionaryAlertsByPersonIdUseCase(_mockGateway.Object);
+        }
+
+        [Test]
+        public async Task ReturnsEmptyAlertsListWhenNoResults()
+        {
+            // Arrange
+            var personId = Guid.NewGuid();
+
+            _mockGateway
+                .Setup(x => x.GetCautionaryAlertsByMMHPersonId(personId))
+                .ReturnsAsync(new List<CautionaryAlertListItem>());
+
+            // Act
+            var result = await _classUnderTest.ExecuteAsync(personId).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.PersonId.Should().Be(personId);
+            result.Alerts.Should().BeEmpty();
+            _mockGateway.Verify(x => x.GetCautionaryAlertsByMMHPersonId(personId), Times.Once);
+        }
+
+        [Test]
+        public async Task ReturnsAlertsFromGateway()
+        {
+            // Arrange
+            var personId = Guid.NewGuid();
+            var mockAlerts = _fixture.CreateMany<CautionaryAlertListItem>();
+
+            _mockGateway
+                .Setup(x => x.GetCautionaryAlertsByMMHPersonId(personId))
+                .ReturnsAsync(mockAlerts);
+
+            // Act
+            var result = await _classUnderTest.ExecuteAsync(personId).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.PersonId.Should().Be(personId);
+            result.Alerts.Should().HaveSameCount(mockAlerts);
+            _mockGateway.Verify(x => x.GetCautionaryAlertsByMMHPersonId(personId), Times.Once);
+        }
+    }
+}

--- a/CautionaryAlertsApi/Startup.cs
+++ b/CautionaryAlertsApi/Startup.cs
@@ -146,6 +146,7 @@ namespace CautionaryAlertsApi
             services.AddScoped<IGetGoogleSheetAlertsForProperty, GetGoogleSheetAlertsForProperty>();
             services.AddScoped<IGetGoogleSheetAlertsForPerson, GetGoogleSheetAlertsForPerson>();
             services.AddScoped<IPropertyAlertsNewUseCase, GetPropertyAlertsNewUseCase>();
+            services.AddScoped<IGetCautionaryAlertsByPersonId, GetCautionaryAlertsByPersonIdUseCase>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/CautionaryAlertsApi/V1/Boundary/Response/CautionaryAlertsMMHPersonResponse.cs
+++ b/CautionaryAlertsApi/V1/Boundary/Response/CautionaryAlertsMMHPersonResponse.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using CautionaryAlertsApi.V1.Domain;
+
+namespace CautionaryAlertsApi.V1.Boundary.Response
+{
+    public class CautionaryAlertsMMHPersonResponse
+    {
+        public Guid PersonId { get; set; }
+        public List<CautionaryAlertResponse> Alerts { get; set; }
+    }
+
+    public class ListMMHPersonsCautionaryAlerts
+    {
+        public List<CautionaryAlertPersonResponse> Contacts { get; set; }
+    }
+}

--- a/CautionaryAlertsApi/V1/Controllers/CautionaryAlertsApiController.cs
+++ b/CautionaryAlertsApi/V1/Controllers/CautionaryAlertsApiController.cs
@@ -19,12 +19,17 @@ namespace CautionaryAlertsApi.V1.Controllers
         private readonly IGetAlertsForPeople _getAlertsForPeople;
         private readonly IGetCautionaryAlertsForProperty _getCautionaryAlertsForProperty;
         private readonly IPropertyAlertsNewUseCase _getPropertyAlertsNewUseCase;
+        private readonly IGetCautionaryAlertsByPersonId _getCautionaryAlertsByPersonId;
 
-        public CautionaryAlertsApiController(IGetAlertsForPeople getAlertsForPeople, IGetCautionaryAlertsForProperty getCautionaryAlertsForProperty, IPropertyAlertsNewUseCase getCautionaryContactAlertsUseCase)
+        public CautionaryAlertsApiController(IGetAlertsForPeople getAlertsForPeople,
+                                             IGetCautionaryAlertsForProperty getCautionaryAlertsForProperty,
+                                             IPropertyAlertsNewUseCase getCautionaryContactAlertsUseCase,
+                                             IGetCautionaryAlertsByPersonId getCautionaryAlertsByPersonId)
         {
             _getAlertsForPeople = getAlertsForPeople;
             _getCautionaryAlertsForProperty = getCautionaryAlertsForProperty;
             _getPropertyAlertsNewUseCase = getCautionaryContactAlertsUseCase;
+            _getCautionaryAlertsByPersonId = getCautionaryAlertsByPersonId;
         }
 
         /// <summary>
@@ -85,6 +90,22 @@ namespace CautionaryAlertsApi.V1.Controllers
         public async Task<IActionResult> GetPropertyAlertsNew(string propertyReference)
         {
             var result = await _getPropertyAlertsNewUseCase.ExecuteAsync(propertyReference).ConfigureAwait(false);
+
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Returns a list of cautionary alerts based on person ID.
+        /// Reads from new table in database to mitigate GS performance issues
+        /// </summary>
+        /// <param name="personId">A unique MMH identifier (GUID) of a person.</param>
+        /// <response code="200">Successful. Returns a list of cautionary alerts for a person.</response>
+        [ProducesResponseType(typeof(CautionaryAlertsPropertyResponse), StatusCodes.Status200OK)]
+        [HttpGet]
+        [Route("persons/{personId}")]
+        public async Task<IActionResult> GetAlertsByPersonId([FromRoute] Guid personId)
+        {
+            var result = await _getCautionaryAlertsByPersonId.ExecuteAsync(personId).ConfigureAwait(false);
 
             return Ok(result);
         }

--- a/CautionaryAlertsApi/V1/Gateways/IUhGateway.cs
+++ b/CautionaryAlertsApi/V1/Gateways/IUhGateway.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using CautionaryAlertsApi.V1.Domain;
@@ -12,5 +13,6 @@ namespace CautionaryAlertsApi.V1.Gateways
 
         Task<IEnumerable<CautionaryAlertListItem>> GetPropertyAlertsNew(string propertyReference);
 
+        Task<IEnumerable<CautionaryAlertListItem>> GetCautionaryAlertsByMMHPersonId(Guid personId);
     }
 }

--- a/CautionaryAlertsApi/V1/Gateways/UhGateway.cs
+++ b/CautionaryAlertsApi/V1/Gateways/UhGateway.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -98,6 +99,15 @@ namespace CautionaryAlertsApi.V1.Gateways
         {
             var alerts = await _uhContext.PropertyAlertsNew
                 .Where(x => x.PropertyReference == propertyReference)
+                .ToListAsync().ConfigureAwait(false);
+
+            return alerts.Select(x => x.ToDomain());
+        }
+
+        public async Task<IEnumerable<CautionaryAlertListItem>> GetCautionaryAlertsByMMHPersonId(Guid personId)
+        {
+            var alerts = await _uhContext.PropertyAlertsNew
+                .Where(x => x.MMHID == personId.ToString())
                 .ToListAsync().ConfigureAwait(false);
 
             return alerts.Select(x => x.ToDomain());

--- a/CautionaryAlertsApi/V1/UseCase/GetCautionaryAlertsByPersonIdUseCase.cs
+++ b/CautionaryAlertsApi/V1/UseCase/GetCautionaryAlertsByPersonIdUseCase.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using CautionaryAlertsApi.V1.Boundary.Response;
+using CautionaryAlertsApi.V1.Gateways;
+using CautionaryAlertsApi.V1.UseCase.Interfaces;
+
+namespace CautionaryAlertsApi.V1.UseCase
+{
+    public class GetCautionaryAlertsByPersonIdUseCase : IGetCautionaryAlertsByPersonId
+    {
+        private readonly IUhGateway _gateway;
+
+        public GetCautionaryAlertsByPersonIdUseCase(IUhGateway gateway)
+        {
+            _gateway = gateway;
+        }
+
+        public async Task<CautionaryAlertsMMHPersonResponse> ExecuteAsync(Guid personId)
+        {
+            var result = await _gateway.GetCautionaryAlertsByMMHPersonId(personId).ConfigureAwait(false);
+
+            return new CautionaryAlertsMMHPersonResponse
+            {
+                PersonId = personId,
+                Alerts = result.Select(r => r.ToResponse()).ToList()
+            };
+        }
+    }
+}

--- a/CautionaryAlertsApi/V1/UseCase/Interfaces/IGetCautionaryAlertsByPersonId.cs
+++ b/CautionaryAlertsApi/V1/UseCase/Interfaces/IGetCautionaryAlertsByPersonId.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Threading.Tasks;
+using CautionaryAlertsApi.V1.Boundary.Response;
+
+namespace CautionaryAlertsApi.V1.UseCase.Interfaces
+{
+    public interface IGetCautionaryAlertsByPersonId
+    {
+        Task<CautionaryAlertsMMHPersonResponse> ExecuteAsync(Guid personId);
+    }
+}


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/MTTL-2773

## Describe this PR

### *What is the problem we're trying to solve*

In order to view discretionary alerts on a person page in MMH, we need an endpoint to get cautionary alerts by MMH person ID. This endpoint will utilise the PSQL database in case the issues with gsheets continue. 

### *What changes have we introduced*

Added an endpoint that queries the db using an MMH person ID.

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated [relevant documentation](https://app.swaggerhub.com/apis-docs/Hackney/cautionary-alerts-api/1.0.0), where necessary
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
