### PR TITLE
Add 'reason' field to API responses

### DIFF
--- a/CautionaryAlertsApi.Tests/V1/UseCase/GetGoogleSheetAlertsForPropertyTests.cs
+++ b/CautionaryAlertsApi.Tests/V1/UseCase/GetGoogleSheetAlertsForPropertyTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using AutoFixture;
+using CautionaryAlertsApi.V1.Factories;
 using CautionaryAlertsApi.V1.Gateways;
 using CautionaryAlertsApi.V1.UseCase;
 using FluentAssertions;

--- a/CautionaryAlertsApi/V1/Boundary/Response/CautionaryAlertResponse.cs
+++ b/CautionaryAlertsApi/V1/Boundary/Response/CautionaryAlertResponse.cs
@@ -34,5 +34,9 @@ namespace CautionaryAlertsApi.V1.Boundary.Response
         /// </summary>
         /// <example>Verbal abuse or threat of</example>
         public string Description { get; set; }
+        /// <summary>
+        /// Detailed description or reason behind the cautionary alert
+        /// </summary>
+        public string Reason { get; set; }
     }
 }

--- a/CautionaryAlertsApi/V1/Factories/EntityFactory.cs
+++ b/CautionaryAlertsApi/V1/Factories/EntityFactory.cs
@@ -70,7 +70,8 @@ namespace CautionaryAlertsApi.V1.Factories
                 Code = entity.Code,
                 CautionOnSystem = entity.CautionOnSystem,
                 PropertyReference = entity.PropertyReference,
-                Name = entity.PersonName
+                Name = entity.PersonName,
+                Reason = entity.Reason
             };
         }
 

--- a/CautionaryAlertsApi/V1/Factories/ResponseFactory.cs
+++ b/CautionaryAlertsApi/V1/Factories/ResponseFactory.cs
@@ -17,7 +17,7 @@ namespace CautionaryAlertsApi.V1.Factories
                 DateModified = domain.DateModified.ToString("yyyy-MM-dd"),
                 EndDate = domain.EndDate?.ToString("yyyy-MM-dd"),
                 ModifiedBy = domain.ModifiedBy,
-                StartDate = domain.StartDate?.ToString("yyyy-MM-dd"),
+                StartDate = domain.StartDate?.ToString("yyyy-MM-dd")
             };
         }
 
@@ -60,6 +60,19 @@ namespace CautionaryAlertsApi.V1.Factories
                 Code = domain.Code,
                 Type = domain.CautionOnSystem,
                 Description = domain.Outcome
+            };
+        }
+
+        public static CautionaryAlertResponse ToResponse(this CautionaryAlertListItem domain)
+        {
+            return new CautionaryAlertResponse
+            {
+                DateModified = domain.DateOfIncident,
+                ModifiedBy = "GoogleSheet",
+                StartDate = domain.DateOfIncident,
+                AlertCode = domain.Code,
+                Description = domain.CautionOnSystem,
+                Reason = domain.Reason
             };
         }
     }

--- a/CautionaryAlertsApi/V1/Infrastructure/GoogleSheets/CautionaryAlertListItem.cs
+++ b/CautionaryAlertsApi/V1/Infrastructure/GoogleSheets/CautionaryAlertListItem.cs
@@ -21,17 +21,6 @@ namespace CautionaryAlertsApi.V1.Gateways
         public string PropertyReference { get; set; }
         public string TenancyDates { get; set; }
         public string IncidentBeforeCurrentTenancyDate { get; set; }
-
-        public CautionaryAlertResponse ToResponse()
-        {
-            return new CautionaryAlertResponse
-            {
-                DateModified = DateOfIncident,
-                ModifiedBy = "GoogleSheet",
-                StartDate = DateOfIncident,
-                AlertCode = Code,
-                Description = CautionOnSystem
-            };
-        }
+        public string Reason { get; set; }
     }
 }

--- a/CautionaryAlertsApi/V1/Infrastructure/PropertyAlertNew.cs
+++ b/CautionaryAlertsApi/V1/Infrastructure/PropertyAlertNew.cs
@@ -51,7 +51,7 @@ namespace CautionaryAlertsApi.V1.Infrastructure
         [MaxLength(36)]
         public string MMHID { get; set; }
 
-        [Column("reason")]
+        [Column("outcome")]
         [MaxLength(100)]
         public string Reason { get; set; }
     }

--- a/CautionaryAlertsApi/V1/Infrastructure/PropertyAlertNew.cs
+++ b/CautionaryAlertsApi/V1/Infrastructure/PropertyAlertNew.cs
@@ -51,5 +51,8 @@ namespace CautionaryAlertsApi.V1.Infrastructure
         [MaxLength(36)]
         public string MMHID { get; set; }
 
+        [Column("reason")]
+        [MaxLength(100)]
+        public string Reason { get; set; }
     }
 }

--- a/CautionaryAlertsApi/V1/UseCase/GetCautionaryAlertsByPersonIdUseCase.cs
+++ b/CautionaryAlertsApi/V1/UseCase/GetCautionaryAlertsByPersonIdUseCase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using CautionaryAlertsApi.V1.Boundary.Response;
+using CautionaryAlertsApi.V1.Factories;
 using CautionaryAlertsApi.V1.Gateways;
 using CautionaryAlertsApi.V1.UseCase.Interfaces;
 

--- a/CautionaryAlertsApi/V1/UseCase/GetPropertyAlertsNewUseCase.cs
+++ b/CautionaryAlertsApi/V1/UseCase/GetPropertyAlertsNewUseCase.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using CautionaryAlertsApi.V1.Boundary.Response;
+using CautionaryAlertsApi.V1.Factories;
 using CautionaryAlertsApi.V1.Gateways;
 
 namespace CautionaryAlertsApi.V1.UseCase

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -635,7 +635,7 @@ create table dbo."PropertyAlertNew"(
 	"uprn" varchar(12),
 	"person_name" varchar(100),
 	"mmh_id" varchar(36),
-	"reason" varchar(100)
+	"outcome" varchar(100)
 );
 
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -634,7 +634,8 @@ create table dbo."PropertyAlertNew"(
 	"property_reference" varchar(12),
 	"uprn" varchar(12),
 	"person_name" varchar(100),
-	"mmh_id" varchar(36)
+	"mmh_id" varchar(36),
+	"reason" varchar(100)
 );
 
 


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/MTTL-2656

## Describe this PR

Add a 'reason' field to the API so that users can view more detailed reasoning behind a cautionary alert.

#### _Checklist_

- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
