### PR TITLE
Optional mmhid

### DIFF
--- a/CautionaryAlertsApi.Tests/V1/E2ETests/GetPropertyAlertsNewE2ETests.cs
+++ b/CautionaryAlertsApi.Tests/V1/E2ETests/GetPropertyAlertsNewE2ETests.cs
@@ -69,7 +69,7 @@ namespace CautionaryAlertsApi.Tests.V1.E2ETests
 
             var results = _fixture.Build<PropertyAlertNew>()
                 .With(x => x.PropertyReference, propertyReference)
-                .Without(x=> x.MMHID)
+                .Without(x => x.MMHID)
                 .CreateMany(numberOfResults);
 
             await TestDataHelper.SavePropertyAlertsToDb(UhContext, results).ConfigureAwait(false);

--- a/CautionaryAlertsApi/CautionaryAlertsApi.csproj
+++ b/CautionaryAlertsApi/CautionaryAlertsApi.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.56.0" />
     <PackageReference Include="Hackney.Core.Validation.AspNet" Version="1.53.0" />
-    <PackageReference Include="Hackney.Shared.CautionaryAlerts" Version="0.7.0" />
+    <PackageReference Include="Hackney.Shared.CautionaryAlerts" Version="0.8.0-feat-optional-mm0002" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.4.1" />

--- a/CautionaryAlertsApi/CautionaryAlertsApi.csproj
+++ b/CautionaryAlertsApi/CautionaryAlertsApi.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.56.0" />
     <PackageReference Include="Hackney.Core.Validation.AspNet" Version="1.53.0" />
-    <PackageReference Include="Hackney.Shared.CautionaryAlerts" Version="0.8.0-feat-optional-mm0002" />
+    <PackageReference Include="Hackney.Shared.CautionaryAlerts" Version="0.8.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.4.1" />


### PR DESCRIPTION
There has been a requirement to make MMH id optional as some cautionary alerts are related to a dwelling rather than the tenant itself