### PR TITLE
Post-cautionary-alerts-new-attributes

### DIFF
--- a/CautionaryAlertsApi.Tests/V1/Factories/ResponseFactoryTest.cs
+++ b/CautionaryAlertsApi.Tests/V1/Factories/ResponseFactoryTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using AutoFixture;
 using Hackney.Shared.CautionaryAlerts.Domain;
 using Hackney.Shared.CautionaryAlerts.Factories;
@@ -19,7 +20,7 @@ namespace CautionaryAlertsApi.Tests.V1.Factories
             response.Description.Should().Be(domain.Description);
             response.AlertCode.Should().Be(domain.AlertCode);
             response.ModifiedBy.Should().Be(domain.ModifiedBy);
-            response.DateModified.Should().Be(DateTimeToDateString(domain.DateModified));
+            response.DateModified.Should().Be(DateTimeToDateString(domain.DateModified.Value));
             response.EndDate.Should().Be(DateTimeToDateString(domain.EndDate.Value));
             response.StartDate.Should().Be(DateTimeToDateString(domain.StartDate.Value));
         }

--- a/CautionaryAlertsApi.Tests/V1/Factories/ResponseFactoryTest.cs
+++ b/CautionaryAlertsApi.Tests/V1/Factories/ResponseFactoryTest.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using AutoFixture;
 using Hackney.Shared.CautionaryAlerts.Domain;
 using Hackney.Shared.CautionaryAlerts.Factories;

--- a/CautionaryAlertsApi.Tests/V1/UseCase/PostNewCautionaryAlertUseCaseTests.cs
+++ b/CautionaryAlertsApi.Tests/V1/UseCase/PostNewCautionaryAlertUseCaseTests.cs
@@ -1,3 +1,4 @@
+using System;
 using AutoFixture;
 using CautionaryAlertsApi.V1.Gateways;
 using Hackney.Shared.CautionaryAlerts.Infrastructure;
@@ -40,7 +41,8 @@ namespace CautionaryAlertsApi.Tests.V1.UseCase
             var cautionaryAlert = CreateCautionaryAlertFixture.GenerateValidCreateCautionaryAlertFixture(defaultString, _fixture, addressString);
             var token = new Token();
 
-            var cautionaryAlertDb = cautionaryAlert.ToDatabase();
+            var alertId = _fixture.Create<Guid>().ToString();
+            var cautionaryAlertDb = cautionaryAlert.ToDatabase(true, alertId);
             var cautionaryToDomain = cautionaryAlertDb.ToPropertyAlertDomain();
 
 

--- a/CautionaryAlertsApi.Tests/V1/UseCase/PostNewCautionaryAlertUseCaseTests.cs
+++ b/CautionaryAlertsApi.Tests/V1/UseCase/PostNewCautionaryAlertUseCaseTests.cs
@@ -42,7 +42,7 @@ namespace CautionaryAlertsApi.Tests.V1.UseCase
             var token = new Token();
 
             var alertId = _fixture.Create<Guid>().ToString();
-            var cautionaryAlertDb = cautionaryAlert.ToDatabase(true, alertId);
+            var cautionaryAlertDb = cautionaryAlert.ToDatabase(isActive: true, alertId);
             var cautionaryToDomain = cautionaryAlertDb.ToPropertyAlertDomain();
 
 

--- a/CautionaryAlertsApi/CautionaryAlertsApi.csproj
+++ b/CautionaryAlertsApi/CautionaryAlertsApi.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.56.0" />
     <PackageReference Include="Hackney.Core.Validation.AspNet" Version="1.53.0" />
-    <PackageReference Include="Hackney.Shared.CautionaryAlerts" Version="0.9.0" />
+    <PackageReference Include="Hackney.Shared.CautionaryAlerts" Version="0.12.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.4.1" />

--- a/CautionaryAlertsApi/V1/Gateways/UhGateway.cs
+++ b/CautionaryAlertsApi/V1/Gateways/UhGateway.cs
@@ -136,7 +136,7 @@ namespace CautionaryAlertsApi.V1.Gateways
         {
             _logger.LogDebug($"Calling Postgress.SaveAsync");
             var alertId = new Guid().ToString();
-            var alertDbEntity = cautionaryAlert.ToDatabase(true, alertId);
+            var alertDbEntity = cautionaryAlert.ToDatabase(isActive: true, alertId);
 
             _uhContext.PropertyAlertsNew.Add(alertDbEntity);
             await _uhContext.SaveChangesAsync().ConfigureAwait(false);

--- a/CautionaryAlertsApi/V1/Gateways/UhGateway.cs
+++ b/CautionaryAlertsApi/V1/Gateways/UhGateway.cs
@@ -12,7 +12,6 @@ using Microsoft.Extensions.Logging;
 using CautionaryAlert = Hackney.Shared.CautionaryAlerts.Domain.CautionaryAlert;
 using Hackney.Shared.CautionaryAlerts.Infrastructure.GoogleSheets;
 using PropertyAlert = Hackney.Shared.CautionaryAlerts.Infrastructure.PropertyAlert;
-using CautionaryAlertsApi.V1.Domain;
 
 namespace CautionaryAlertsApi.V1.Gateways
 {
@@ -135,7 +134,8 @@ namespace CautionaryAlertsApi.V1.Gateways
         public async Task<PropertyAlertDomain> PostNewCautionaryAlert(CreateCautionaryAlert cautionaryAlert)
         {
             _logger.LogDebug($"Calling Postgress.SaveAsync");
-            var alertDbEntity = cautionaryAlert.ToDatabase();
+            var alertId = new Guid().ToString();
+            var alertDbEntity = cautionaryAlert.ToDatabase(true, alertId);
 
             _uhContext.PropertyAlertsNew.Add(alertDbEntity);
             await _uhContext.SaveChangesAsync().ConfigureAwait(false);

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -636,5 +636,7 @@ create table dbo."PropertyAlertNew"(
 	"person_name" varchar(100),
 	"mmh_id" varchar(36),
 	"outcome" varchar(100),
-	"assure_reference" varchar(12)
+	"assure_reference" varchar(12),
+  "is_active" Boolean NOT NULL,
+  "alert_id" varchar(36)
 );

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,6 @@ services:
       - dev-database
   dev-database:
     environment:
-      - ACCEPT_EULA=Y
       - POSTGRES_PASSWORD=mypassword
     image: postgres:12
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       - ACCEPT_EULA=Y
       - POSTGRES_PASSWORD=mypassword
     image: postgres:12
+    ports:
+      - "5432:5432"
     volumes:
       - ./database:/docker-entrypoint-initdb.d
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,9 @@ services:
     links:
       - dev-database
   dev-database:
-    env_file:
-      - database.env
+    environment:
+      - ACCEPT_EULA=Y
+      - POSTGRES_PASSWORD=mypassword
     image: postgres:12
     volumes:
       - ./database:/docker-entrypoint-initdb.d
@@ -53,15 +54,15 @@ services:
 
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
-    image: localstack/localstack    
-    hostname: awslocal    
+    image: localstack/localstack
+    hostname: awslocal
     ports:
-      - "4566:4566"      
+      - "4566:4566"
     environment:
       - SERVICES=sns
-      - DEBUG=1                  
+      - DEBUG=1
       - DOCKER_HOST=unix:///var/run/docker.sock
-      - HOST_TMP_FOLDER=/tmp/localstack      
+      - HOST_TMP_FOLDER=/tmp/localstack
     volumes:
       - "./.localstack:/tmp/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"


### PR DESCRIPTION
alertId and isActive now passed to ToDatabase method as in the source

Relates to [POH-32](https://hackney.atlassian.net/jira/software/projects/POH/boards/100?selectedIssue=POH-32)
As a housing officer I need to end a cautionary alert, so that we have accurate information against a resident

## Describe this PR

### *What is the problem we're trying to solve*

We want to be able to let alerts be ended from API clients. This required creating these two new fields, that must now be passed to the ToDatabase method.

ToDatabase method in the new Hackney.Shared.CautionaryAlerts package requires alertId and isActive fields, which are now added in the UseCase here.


[POH-32]: https://hackney.atlassian.net/browse/POH-32?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ