### PR TITLE
Fixed the guid creation function to create a random guid

### DIFF
--- a/CautionaryAlertsApi/V1/Gateways/UhGateway.cs
+++ b/CautionaryAlertsApi/V1/Gateways/UhGateway.cs
@@ -135,7 +135,7 @@ namespace CautionaryAlertsApi.V1.Gateways
         public async Task<PropertyAlertDomain> PostNewCautionaryAlert(CreateCautionaryAlert cautionaryAlert)
         {
             _logger.LogDebug($"Calling Postgress.SaveAsync");
-            var alertId = new Guid().ToString();
+            var alertId = Guid.NewGuid().ToString();
             var alertDbEntity = cautionaryAlert.ToDatabase(isActive: true, alertId);
 
             _uhContext.PropertyAlertsNew.Add(alertDbEntity);


### PR DESCRIPTION
Was previously creating a blank Guid.
Can't be automatically tested in this context as methods are from the nuget package.
Will be manually tested on development to verify.

Will be updating the Nuget package as well to ensure alert ID is returned from the POST method (even though this may not be needed right now).

