### PR TITLE
removed personId reference from get alert by alertId

### DIFF
--- a/CautionaryAlertsApi.Tests/V1/E2ETests/GetAlertsByAlertIdE2ETests.cs
+++ b/CautionaryAlertsApi.Tests/V1/E2ETests/GetAlertsByAlertIdE2ETests.cs
@@ -31,7 +31,7 @@ namespace CautionaryAlertsApi.Tests.V1.E2ETests
 
             await TestDataHelper.SavePropertyAlertToDb(UhContext, alerts).ConfigureAwait(false);
 
-            var url = new Uri($"/api/v1/cautionary-alerts/persons/{personId}/alerts/{alertId}", UriKind.Relative);
+            var url = new Uri($"/api/v1/cautionary-alerts/alert/{alertId}", UriKind.Relative);
             // Act
             var response = await Client.GetAsync(url).ConfigureAwait(true);
 
@@ -49,10 +49,9 @@ namespace CautionaryAlertsApi.Tests.V1.E2ETests
         public async Task ReturnsNotFoundWhenAlertDoesNotExist()
         {
             // Arrange
-            var personId = Guid.NewGuid();
             var alertId = Guid.NewGuid();
 
-            var url = new Uri($"/api/v1/cautionary-alerts/persons/{personId}/alerts/{alertId}", UriKind.Relative);
+            var url = new Uri($"/api/v1/cautionary-alerts/alert/{alertId}", UriKind.Relative);
             // Act
             var response = await Client.GetAsync(url).ConfigureAwait(true);
 
@@ -64,19 +63,17 @@ namespace CautionaryAlertsApi.Tests.V1.E2ETests
         public async Task Returns500WhenMoreThanOneAlertRetrievedFromDb()
         {
             // Arrange
-            var personId = Guid.NewGuid();
             var alertId = Guid.NewGuid();
             var dateOfIncident = "12/12/2020";
 
             var alerts = _fixture.Build<PropertyAlertNew>()
-                .With(x => x.MMHID, personId.ToString())
                 .With(x => x.AlertId, alertId.ToString())
                 .With(x => x.DateOfIncident, dateOfIncident)
                 .CreateMany();
 
             await TestDataHelper.SavePropertyAlertsToDb(UhContext, alerts).ConfigureAwait(false);
 
-            var url = new Uri($"/api/v1/cautionary-alerts/persons/{personId}/alerts/{alertId}", UriKind.Relative);
+            var url = new Uri($"/api/v1/cautionary-alerts/alert/{alertId}", UriKind.Relative);
             // Act
             var response = await Client.GetAsync(url).ConfigureAwait(true);
 

--- a/CautionaryAlertsApi.Tests/V1/Gateways/UhGatewayTests.cs
+++ b/CautionaryAlertsApi.Tests/V1/Gateways/UhGatewayTests.cs
@@ -458,7 +458,6 @@ namespace CautionaryAlertsApi.Tests.V1.Gateways
 
             var dateOfIncident = "12/12/2020";
             var alert = _fixture.Build<PropertyAlertNew>()
-                .With(x => x.MMHID, query.PersonId.ToString())
                 .With(x => x.AlertId, query.AlertId.ToString())
                 .With(x => x.DateOfIncident, dateOfIncident)
                 .Create();
@@ -481,7 +480,6 @@ namespace CautionaryAlertsApi.Tests.V1.Gateways
 
             var dateOfIncident = "12/12/2020";
             var alert = _fixture.Build<PropertyAlertNew>()
-                .With(x => x.MMHID, query.PersonId.ToString())
                 .With(x => x.AlertId, query.AlertId.ToString())
                 .With(x => x.DateOfIncident, dateOfIncident)
                 .Create();
@@ -501,7 +499,6 @@ namespace CautionaryAlertsApi.Tests.V1.Gateways
 
             var dateOfIncident = "12/12/2020";
             var alerts = _fixture.Build<PropertyAlertNew>()
-                .With(x => x.MMHID, query.PersonId.ToString())
                 .With(x => x.AlertId, query.AlertId.ToString())
                 .With(x => x.DateOfIncident, dateOfIncident)
                 .CreateMany(3);

--- a/CautionaryAlertsApi.Tests/V1/UseCase/GetCautionaryAleryByAlertIdUseCaseTests.cs
+++ b/CautionaryAlertsApi.Tests/V1/UseCase/GetCautionaryAleryByAlertIdUseCaseTests.cs
@@ -32,7 +32,6 @@ namespace CautionaryAlertsApi.Tests.V1.UseCase
             // Arrange
             var query = _fixture.Create<AlertQueryObject>();
             var mockAlert = _fixture.Build<CautionaryAlert>()
-                                     .With(x => x.PersonId, query.PersonId)
                                      .With(x => x.AlertId, query.AlertId)
                                      .Create();
 
@@ -45,7 +44,6 @@ namespace CautionaryAlertsApi.Tests.V1.UseCase
 
             // Assert
             result.Should().NotBeNull();
-            result.PersonId.Should().Be(query.PersonId);
             result.AlertId.Should().Be(query.AlertId);
             _mockGateway.Verify(x => x.GetCautionaryAlertByAlertId(query), Times.Once);
         }

--- a/CautionaryAlertsApi/CautionaryAlertsApi.csproj
+++ b/CautionaryAlertsApi/CautionaryAlertsApi.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.56.0" />
     <PackageReference Include="Hackney.Core.Validation.AspNet" Version="1.53.0" />
-    <PackageReference Include="Hackney.Shared.CautionaryAlerts" Version="0.15.0" />
+    <PackageReference Include="Hackney.Shared.CautionaryAlerts" Version="0.16.0-feat-end-caution0004" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.4.1" />

--- a/CautionaryAlertsApi/CautionaryAlertsApi.csproj
+++ b/CautionaryAlertsApi/CautionaryAlertsApi.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -31,7 +31,7 @@
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.56.0" />
     <PackageReference Include="Hackney.Core.Validation.AspNet" Version="1.53.0" />
-    <PackageReference Include="Hackney.Shared.CautionaryAlerts" Version="0.16.0-feat-end-caution0004" />
+    <PackageReference Include="Hackney.Shared.CautionaryAlerts" Version="0.17.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.4.1" />

--- a/CautionaryAlertsApi/V1/Controllers/CautionaryAlertsApiController.cs
+++ b/CautionaryAlertsApi/V1/Controllers/CautionaryAlertsApiController.cs
@@ -137,7 +137,7 @@ namespace CautionaryAlertsApi.V1.Controllers
         /// </summary>
         [ProducesResponseType(typeof(CautionaryAlertResponse), StatusCodes.Status200OK)]
         [HttpGet]
-        [Route("persons/{personId}/alerts/{alertId}")]
+        [Route("alert/{alertId}")]
         public IActionResult GetAlertByAlertId([FromRoute] AlertQueryObject query)
         {
             var result = _getCautionaryAlertByAlertId.ExecuteAsync(query);

--- a/CautionaryAlertsApi/V1/Gateways/UhGateway.cs
+++ b/CautionaryAlertsApi/V1/Gateways/UhGateway.cs
@@ -136,7 +136,6 @@ namespace CautionaryAlertsApi.V1.Gateways
         public CautionaryAlert GetCautionaryAlertByAlertId(AlertQueryObject query)
         {
             var alerts = _uhContext.PropertyAlertsNew
-                        .Where(x => x.MMHID == query.PersonId.ToString())
                         .Where(x => x.AlertId == query.AlertId.ToString());
 
             var cautionaryAlert = alerts.Select(x => x.ToCautionaryAlertDomain());


### PR DESCRIPTION
For the Get Alert by alertId and end cautionary alert endpoints person id should not be required as there can be alerts assigned to a property and not a person.