### PR TITLE
update shared nuget version

### DIFF
--- a/CautionaryAlertsApi.Tests/V1/UseCase/GetCautionaryAlertsByPersonIdUseCaseTests.cs
+++ b/CautionaryAlertsApi.Tests/V1/UseCase/GetCautionaryAlertsByPersonIdUseCaseTests.cs
@@ -52,6 +52,7 @@ namespace CautionaryAlertsApi.Tests.V1.UseCase
             var personId = Guid.NewGuid();
             var mockAlerts = _fixture.Build<CautionaryAlertListItem>()
                                      .With(x => x.PersonId, personId.ToString())
+                                     .With(x => x.AlertId, Guid.NewGuid().ToString())
                                      .CreateMany();
 
             _mockGateway

--- a/CautionaryAlertsApi.Tests/V1/UseCase/GetGoogleSheetAlertsForPropertyTests.cs
+++ b/CautionaryAlertsApi.Tests/V1/UseCase/GetGoogleSheetAlertsForPropertyTests.cs
@@ -34,6 +34,7 @@ namespace CautionaryAlertsApi.Tests.V1.UseCase
 
             var cautionaryAlert = _fixture.Build<CautionaryAlertListItem>()
                                           .With(x => x.PersonId, Guid.NewGuid().ToString())
+                                          .With(x => x.AlertId, Guid.NewGuid().ToString())
                                           .Create();
 
             cautionaryAlertList.Add(cautionaryAlert);

--- a/CautionaryAlertsApi.Tests/V1/UseCase/GetPropertyAlertsNewUseCaseTests.cs
+++ b/CautionaryAlertsApi.Tests/V1/UseCase/GetPropertyAlertsNewUseCaseTests.cs
@@ -55,6 +55,7 @@ namespace CautionaryAlertsApi.Tests.V1.UseCase
 
             var alerts = _fixture.Build<CautionaryAlertListItem>()
                                  .With(x => x.PersonId, personId.ToString())
+                                 .With(x => x.AlertId, Guid.NewGuid().ToString())
                                  .CreateMany(numberOfResults);
 
             _mockGateway

--- a/CautionaryAlertsApi/CautionaryAlertsApi.csproj
+++ b/CautionaryAlertsApi/CautionaryAlertsApi.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.56.0" />
     <PackageReference Include="Hackney.Core.Validation.AspNet" Version="1.53.0" />
-    <PackageReference Include="Hackney.Shared.CautionaryAlerts" Version="0.18.0" />
+    <PackageReference Include="Hackney.Shared.CautionaryAlerts" Version="0.19.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.4.1" />


### PR DESCRIPTION
The Cautionary Alert Shared Nuget version needs to be updated to fix Alert Id empty guid issue as described in [this PR](https://github.com/LBHackney-IT/cautionary-alerts-shared/pull/19). 