### PR TITLE
end cautionary alert AH to be person id

### DIFF
--- a/CautionaryAlertsApi.Tests/V1/E2ETests/EndCautionartAlertE2ETests.cs
+++ b/CautionaryAlertsApi.Tests/V1/E2ETests/EndCautionartAlertE2ETests.cs
@@ -68,7 +68,7 @@ namespace CautionaryAlertsApi.Tests.V1.E2ETests
             //Sns event sent 
             Action<CautionaryAlertSns> verifyFunc = (snsEvent) =>
             {
-                snsEvent.EntityId.Should().Be(alertId);
+                snsEvent.EntityId.Should().Be(activeAlert.PersonDetails.Id);
                 snsEvent.User.Name.Should().Be("Tester");
                 snsEvent.User.Email.Should().Be("e2e-testing@development.com");
                 System.Text.Json.JsonSerializer.Deserialize<PropertyAlertDomain>(

--- a/CautionaryAlertsApi.Tests/V1/UseCase/EndCautionaryAlertUseCaseTests.cs
+++ b/CautionaryAlertsApi.Tests/V1/UseCase/EndCautionaryAlertUseCaseTests.cs
@@ -37,10 +37,12 @@ namespace CautionaryAlertsApi.Tests.V1.UseCase
             //Arrange 
             var token = new Token();
             var alertId = Guid.NewGuid();
+            var personid = Guid.NewGuid();
 
             var mockExistingAlert = _fixture
                 .Build<PropertyAlertDomain>()
                 .With(a => a.AlertId, alertId.ToString())
+                .With(p => p.MMHID, personid.ToString())
                 .Create();
 
             var endAlertData = _fixture.Create<AlertQueryObject>();

--- a/CautionaryAlertsApi/V1/Factories/CautionaryAlertsSnsFactory.cs
+++ b/CautionaryAlertsApi/V1/Factories/CautionaryAlertsSnsFactory.cs
@@ -38,7 +38,7 @@ namespace CautionaryAlertsApi.V1.Factories
             {
                 CorrelationId = Guid.NewGuid(),
                 DateTime = DateTime.UtcNow,
-                EntityId = Guid.Parse(alert.AlertId),
+                EntityId = Guid.Parse(alert.MMHID),
                 Id = Guid.NewGuid(),
                 EventType = Constants.ENDED_EVENTTYPE,
                 Version = Constants.V1_VERSION,


### PR DESCRIPTION
Currently, when a Cautionary Alert is ended it sends though an sns message with alert id as the entity id, however, this means that we cannot show the Activity history on the person page. Hence I would like to change the method so that it sends through the mmh id (person id) as the entity id. 