### PR TITLE
Revert "Update dev and staging lambda authorizer"

### DIFF
--- a/CautionaryAlertsApi/serverless.yml
+++ b/CautionaryAlertsApi/serverless.yml
@@ -27,7 +27,7 @@ functions:
           path: /{proxy+}
           method: ANY
           authorizer:
-            arn: ${self:custom.authorizerArns.${opt:stage}}
+            arn: ${ssm:/platform-apis-lambda-authorizer-arn}
             type: request
           cors:
             origin: '*'
@@ -103,10 +103,6 @@ resources:
                     - "lambda:InvokeFunction"
                   Resource: "*"
 custom:
-  authorizerArns:
-    development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-new-development-apiauthverifytokennew
-    staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
-    production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-production-apiauthverifytoken
   vpc:
     development:
       securityGroupIds:


### PR DESCRIPTION
Reverts LBHackney-IT/cautionary-alerts-api#109

We're getting 403 issues even though the new authorizer seems to be returning successfully. 

I'm going to try reverting this for now and coming back to it as it's not clear why this is failing after some investigation and perhaps some of the other deployments will clarify this