### PR TITLE
Remove API key requirement to match prod

### DIFF
--- a/CautionaryAlertsApi/serverless.yml
+++ b/CautionaryAlertsApi/serverless.yml
@@ -42,6 +42,7 @@ functions:
               - X-Hackney-User
             allowCredentials: false
           private: true
+          apiKeyRequired: false
 resources:
   Resources:
     lambdaExecutionRole:

--- a/CautionaryAlertsApi/serverless.yml
+++ b/CautionaryAlertsApi/serverless.yml
@@ -41,8 +41,7 @@ functions:
               - x-correlation-id
               - X-Hackney-User
             allowCredentials: false
-          private: true
-          apiKeyRequired: false
+          private: false
 resources:
   Resources:
     lambdaExecutionRole:


### PR DESCRIPTION
Currently requests to this API are failing with Unauthorized despite using the same auth headers as prod. The only difference I can see in this area is staging requires an API Key. I'm not sure if it required it before, but it's worth trying to switch it off to match prod.

It will still verify the user's JWT as normal via the Hackney authorizer.

Staging:
![image](https://github.com/user-attachments/assets/7403e564-7a9b-4bd2-a564-41c5f1d7386a)

Prod:
![image](https://github.com/user-attachments/assets/2bf2b370-ac7c-494a-a157-c30bda3b671e)