### PR TITLE
Re-apply "Callum/try fix 403 error"

### DIFF
--- a/CautionaryAlertsApi/serverless.yml
+++ b/CautionaryAlertsApi/serverless.yml
@@ -29,6 +29,9 @@ functions:
           authorizer:
             arn: ${self:custom.authorizerArns.${opt:stage}}
             type: request
+            resultTtlInSeconds: 0
+            identitySource: method.request.header.Authorization
+            managedExternally: true
           cors:
             origin: '*'
             headers:


### PR DESCRIPTION
Reverts LBHackney-IT/cautionary-alerts-api#114 to fix the cautionary alerts caching issue.

For some reason on staging and only on staging a default cache gets set up of 300 seconds which is causing requests to fail