### PR TITLE
SSI-825 update dev authorizer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,8 @@ jobs:
   build-and-test:
     executor: docker-python
     steps:
-      - checkout
+      - checkout:
+          method: full
       - setup_remote_docker
       - run:
           name: build

--- a/CautionaryAlertsApi/serverless.yml
+++ b/CautionaryAlertsApi/serverless.yml
@@ -107,7 +107,7 @@ resources:
                   Resource: "*"
 custom:
   authorizerArns:
-    development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-new-development-apiauthverifytokennew
+    development: arn:aws:lambda:eu-west-2:859159924354:function:api-gateway-lambda-authorizer
     staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
     production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
   vpc:


### PR DESCRIPTION
## Link to JIRA ticket

[SSI-825](https://hackney.atlassian.net/browse/SSI-825)

## Describe this PR

### *What is the problem we're trying to solve*

We have implemented a new API gateway authorizer that supports both the legacy hackneyToken as well as the new hackneyCognitoToken. This enables us to start migrating the front end application over to the new Cognito auth MFE which uses new Cognito based tokens. Without switching to the new authorizer all API calls from clients calling the API will fail due to the current authorizer not supporting the Cognito tokens.

### *What changes have we introduced*

Update the development authorizer.

Unrelated changes:
Update the checkout config, so SonarCloud gets all the data it needs for scanning. CircleCi recently migrated over to blobless checkouts which means the SonarCloud scan doesn't have all the details from the repo to fully analyze the code and therefore throws an error.


#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

N/A


[SSI-825]: https://hackney.atlassian.net/browse/SSI-825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ