### PR TITLE
Update the JWT core package to get the latest Token Factory that supports Cognito token.

### DIFF
--- a/CautionaryAlertsApi.Tests/CautionaryAlertsApi.Tests.csproj
+++ b/CautionaryAlertsApi.Tests/CautionaryAlertsApi.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Google.Apis.Sheets.v4" Version="1.51.0.2338" />
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
-    <PackageReference Include="Hackney.Core.JWT" Version="1.72.0" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.87.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Core.Testing.Sns" Version="1.71.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />

--- a/CautionaryAlertsApi/CautionaryAlertsApi.csproj
+++ b/CautionaryAlertsApi/CautionaryAlertsApi.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Google.Apis.Sheets.v4" Version="1.51.0.2338" />
     <PackageReference Include="Hackney.Core.Authorization" Version="1.78.0" />
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
-    <PackageReference Include="Hackney.Core.JWT" Version="1.72.0" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.87.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Core.Testing.Sns" Version="1.71.0" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />


### PR DESCRIPTION
# What:
 - Update the `Hackney.Core.JWT` package 2 versions up _(1.72 -> 1.84 -> 1.87)_.

# Why:
 - To get the latest version of the `ITokenFactory` implementation that adds support for the Cognito token schema.
 - The current v1.72 implementation crashes upon encountering Cognito Token due to empty `groups` key failing to map and leading `Token.Groups` to getting set as unhandled `null`.

# Notes:
 - Updating only the `JWT` core package without the `Authorizer` as after additional digging through source code I've found that `Authorizer` core package merely references the `JWT` core package's `ITokenFactory` interface definition, and does not do anything more with the package. The way the Google groups authentication setup works is that for any given API, it uses `JWT` core package to register `TokenFactory` instance DI, and then that gets used by the Authorizer middleware to populate its Auth filter dependencies. The rest of the `JWT` usage seems to be limited down to `Token` class to extract data like email or user name for Activity History purposes.
 - Not updating the Authorizer as it seems to have additional functionality introduced apart JWT version upgrade, that would need extra testing. As it stands right now, due to the above reason, it does not need to be bumped on the APIs.
 - The version `1.84` was a fake release, accidentally triggered by some house cleaning done by the cyber team.
 - What changes does latest JWT intoduce? See PR: https://github.com/LBHackney-IT/lbh-core/pull/68.