### PR TITLE
update staging authorizer

### DIFF
--- a/CautionaryAlertsApi/serverless.yml
+++ b/CautionaryAlertsApi/serverless.yml
@@ -108,7 +108,7 @@ resources:
 custom:
   authorizerArns:
     development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-new-development-apiauthverifytokennew
-    staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
+    staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-gateway-lambda-authorizer
     production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
   vpc:
     development:


### PR DESCRIPTION
## Link to JIRA ticket

[SSI-866](https://hackney.atlassian.net/browse/SSI-866)

## Describe this PR

### *What is the problem we're trying to solve*

Currently the MMH dev site is pointing to staging cautionary alerts API. MMH dev has been updated to use the new Cognito auth MFE, so the API calls are failing because the current staging authorizer can't handle the new Cognito tokens.

This is causing issues in e2e tests as well as for users trying to use the MMH dev site.

### *What changes have we introduced*

Update the staging authorizer to the new one that supports Cognito tokens.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

N/A


[SSI-866]: https://hackney.atlassian.net/browse/SSI-866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ