### PR TITLE
Add TF preview, deploy the CA API instance to `development` environment after fixing pipeline blockers via AWS console.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
+  node: circleci/node@6.3.0
 
 executors:
   docker-python:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,11 +84,7 @@ commands:
       - *attach_workspace
       - checkout
       - setup_remote_docker
-      - run:
-          name: Install Node.js
-          command: |
-            curl -sL https://deb.nodesource.com/setup_18.x | bash -
-            apt-get update && apt-get install -y nodejs
+      - node/install
       - run:
           name: Install serverless CLI
           command: npm i -g serverless

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,9 +224,9 @@ workflows:
               ignore:
                 - development
                 - master
-      - preview-development-terraform:
+      - preview-staging-terraform:
           requires:
-            - assume-role-development
+            - assume-role-staging
 
       - assume-role-production:
           context: api-assume-role-production-context
@@ -235,9 +235,9 @@ workflows:
               ignore:
                 - development
                 - master
-      - preview-development-terraform:
+      - preview-production-terraform:
           requires:
-            - assume-role-development
+            - assume-role-production
 
   check-and-deploy-development:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,25 @@ commands:
           root: *workspace_root
           paths:
             - .aws
+  terraform-preview:
+    description: "Initializes and applies terraform configuration"
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform get -update=true
+            terraform init
+          name: get and init
+      - run:
+          name: plan
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform plan
   terraform-init-then-apply:
     description: "Initializes and applies terraform configuration"
     parameters:
@@ -136,6 +155,11 @@ jobs:
     steps:
       - terraform-init-then-apply:
           environment: "production"
+  preview-development-terraform:
+    executor: docker-terraform
+    steps:
+      - terraform-preview:
+          environment: "development"
   deploy-to-development:
     executor: docker-dotnet
     steps:
@@ -153,7 +177,7 @@ jobs:
           stage: "production"
 
 workflows:
-  check:
+  feature:
     jobs:
       - check-code-formatting:
           context: api-nuget-token-context
@@ -171,6 +195,11 @@ workflows:
               ignore:
                 - development
                 - master
+      - assume-role-development:
+          context: api-assume-role-development-context
+      - preview-development-terraform:
+          requires:
+            - assume-role-development
 
   check-and-deploy-development:
     jobs:
@@ -239,4 +268,3 @@ workflows:
           requires:
             - permit-production-release
             - terraform-init-and-apply-to-production
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,6 +160,16 @@ jobs:
     steps:
       - terraform-preview:
           environment: "development"
+  preview-staging-terraform:
+    executor: docker-terraform
+    steps:
+      - terraform-preview:
+          environment: "staging"
+  preview-production-terraform:
+    executor: docker-terraform
+    steps:
+      - terraform-preview:
+          environment: "production"
   deploy-to-development:
     executor: docker-dotnet
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,6 +207,33 @@ workflows:
                 - master
       - assume-role-development:
           context: api-assume-role-development-context
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - preview-development-terraform:
+          requires:
+            - assume-role-development
+
+      - assume-role-staging:
+          context: api-assume-role-staging-context
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - preview-development-terraform:
+          requires:
+            - assume-role-development
+
+      - assume-role-production:
+          context: api-assume-role-production-context
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
       - preview-development-terraform:
           requires:
             - assume-role-development

--- a/CautionaryAlertsApi/serverless.yml
+++ b/CautionaryAlertsApi/serverless.yml
@@ -33,7 +33,7 @@ functions:
             identitySource: method.request.header.Authorization
             managedExternally: true
           cors:
-            origin: '*'
+            origin: "*"
             headers:
               - Content-Type
               - X-Amz-Date
@@ -53,7 +53,7 @@ resources:
         Path: /${self:service}/${self:provider.stage}/
         RoleName: ${self:service}-lambdaExecutionRole
         AssumeRolePolicyDocument:
-          Version: '2012-10-17'
+          Version: "2012-10-17"
           Statement:
             - Effect: Allow
               Principal:
@@ -65,7 +65,7 @@ resources:
         Policies:
           - PolicyName: postToSns
             PolicyDocument:
-              Version: '2012-10-17'
+              Version: "2012-10-17"
               Statement:
                 - Effect: Allow
                   Action:
@@ -74,7 +74,7 @@ resources:
                     - ${ssm:/sns-topic/${self:provider.stage}/cautionary-alerts/arn}
           - PolicyName: manageLogs
             PolicyDocument:
-              Version: '2012-10-17'
+              Version: "2012-10-17"
               Statement:
                 - Effect: Allow
                   Action:
@@ -82,12 +82,12 @@ resources:
                     - logs:CreateLogStream
                     - logs:PutLogEvents
                   Resource:
-                    - 'Fn::Join':
-                        - ':'
-                        - - 'arn:aws:logs'
-                          - Ref: 'AWS::Region'
-                          - Ref: 'AWS::AccountId'
-                          - 'log-group:/aws/lambda/*:*:*'
+                    - "Fn::Join":
+                        - ":"
+                        - - "arn:aws:logs"
+                          - Ref: "AWS::Region"
+                          - Ref: "AWS::AccountId"
+                          - "log-group:/aws/lambda/*:*:*"
                 - Effect: "Allow"
                   Action:
                     - "s3:PutObject"
@@ -99,7 +99,7 @@ resources:
                         - "Ref": "ServerlessDeploymentBucket"
           - PolicyName: lambdaInvocation
             PolicyDocument:
-              Version: '2012-10-17'
+              Version: "2012-10-17"
               Statement:
                 - Effect: Allow
                   Action:
@@ -108,8 +108,8 @@ resources:
 custom:
   authorizerArns:
     development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-new-development-apiauthverifytokennew
-    staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
-    production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
+    staging: arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
+    production: arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
   vpc:
     development:
       securityGroupIds:


### PR DESCRIPTION
# What:
 - Bump up Cautionary Alerts APIs pipeline's node version.
 - Add Terraform preview steps to observe for any TF drift.

# Why:
 - Cleaner run.
 - Need to deploy CA API to development environment.

# Notes:
 - This is part of the work for resolving MMH technical debt of CA alerts not having a development environment and instead hooking into staging environment. This loose and what should be not allowed environment separation is causing the MMH development environment to fail when under new authentication system that assumes clean environment separation.
 - To get this done additional AWS console work had to be done to create a copy of the database, and correctly populate the environment variables associated with the environment. Additionally, after this is merged, environment variables need to be populated to point to the development CA API, not staging. Though, that will likely have to wait until authorizer is updated.
 - Jira ticket: https://hackney.atlassian.net/browse/SSI-976