### PR TITLE
Switch lambda's `production` authorizer to new Cognito authorizer.

### DIFF
--- a/CautionaryAlertsApi/serverless.yml
+++ b/CautionaryAlertsApi/serverless.yml
@@ -109,7 +109,7 @@ custom:
   authorizerArns:
     development: arn:aws:lambda:eu-west-2:859159924354:function:api-gateway-lambda-authorizer
     staging: arn:aws:lambda:eu-west-2:715003523189:function:api-gateway-lambda-authorizer
-    production: arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
+    production: arn:aws:lambda:eu-west-2:153306643385:function:api-gateway-lambda-authorizer
   vpc:
     development:
       securityGroupIds:


### PR DESCRIPTION
# What:
 - Switch the old legacy lambda authorizer to the new Cognito-supporting one.

# Why:
 - Part of the work of rolling out AWS Cognito authentication flow to `production`.